### PR TITLE
b736546 - Add Inquire for Price on variants that are not purchasable

### DIFF
--- a/templates/layout/base.html
+++ b/templates/layout/base.html
@@ -75,4 +75,21 @@
         {{{footer.scripts}}}
 
     </body>
+    <script>
+        // if the template file is a product template
+        if ("{{template_file}}".includes("product")) {
+            // callback function for the observer to call
+            const callback = (mutationList, observer) => {
+                // if the quantity input is disabled (variant isn't purchasable)
+                if(mutationList[0].target.disabled) {
+                    // change the price label
+                    document.querySelectorAll(".price").forEach(price => price.innerText = "Inquire for Price");
+                }
+            };
+            // create an observer to listen for mutations and call the callback function on mutate
+            const observer = new MutationObserver(callback);
+            // observe the quantity input to mutate on attribute change (style attribute changes visibility)
+            observer.observe(document.getElementById("qty[]"), { attributes: true });
+        }
+    </script>
 </html>


### PR DESCRIPTION
Tim wants to show "Inquire for Purchase" on the Drum sized variants. This requires the variants to be not purchasable on the product settings in BigCommerce.

This code listens for the quantity selection on the product page to be disabled. The quantity selection is disabled when a variant that is not purchasable is selected. When this variant is selected, the price is changed to say "Inquire for Price". When a variant is selected that is purchasable, the price is reflected as expected.